### PR TITLE
Add Budgets resource and associate Users with it

### DIFF
--- a/lib/open_budget/authentication/user.ex
+++ b/lib/open_budget/authentication/user.ex
@@ -10,12 +10,15 @@ defmodule OpenBudget.Authentication.User do
   use Ecto.Schema
   import Ecto.Changeset
   alias OpenBudget.Authentication.User
+  alias OpenBudget.Budgets.BudgetUser
   alias Comeonin.Argon2
 
   schema "users" do
     field :email, :string
     field :password, :string, virtual: true
     field :password_hash, :string
+    many_to_many :budgets, OpenBudget.Budgets.Budget,
+                join_through: BudgetUser, unique: true
 
     timestamps()
   end

--- a/lib/open_budget/budgets/budget.ex
+++ b/lib/open_budget/budgets/budget.ex
@@ -5,10 +5,13 @@ defmodule OpenBudget.Budgets.Budget do
   use Ecto.Schema
   import Ecto.Changeset
   alias OpenBudget.Budgets.Budget
+  alias OpenBudget.Budgets.BudgetUser
+  alias OpenBudget.Authentication.User
 
   schema "budgets" do
     field :description, :string
     field :name, :string
+    many_to_many :users, User, join_through: BudgetUser, unique: true
 
     timestamps()
   end

--- a/lib/open_budget/budgets/budget.ex
+++ b/lib/open_budget/budgets/budget.ex
@@ -1,0 +1,22 @@
+defmodule OpenBudget.Budgets.Budget do
+  @moduledoc """
+  Budgets are where most budget-related data should be associated with.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias OpenBudget.Budgets.Budget
+
+  schema "budgets" do
+    field :description, :string
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(%Budget{} = budget, attrs) do
+    budget
+    |> cast(attrs, [:name, :description])
+    |> validate_required([:name, :description])
+  end
+end

--- a/lib/open_budget/budgets/budget_user.ex
+++ b/lib/open_budget/budgets/budget_user.ex
@@ -1,0 +1,22 @@
+defmodule OpenBudget.Budgets.BudgetUser do
+  @moduledoc """
+  This is the join table for Budgets and Users
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias OpenBudget.Budgets.Budget
+  alias OpenBudget.Budgets.BudgetUser
+  alias OpenBudget.Authentication.User
+
+  @primary_key false
+  schema "budgets_users" do
+    belongs_to :budget, Budget
+    belongs_to :user, User
+  end
+
+  def changeset(%BudgetUser{} = budget_user, attrs \\ %{}) do
+    budget_user
+    |> cast(attrs, [:budget_id, :user_id])
+    |> validate_required([:budget_id, :user_id])
+  end
+end

--- a/lib/open_budget/budgets/budgets.ex
+++ b/lib/open_budget/budgets/budgets.ex
@@ -101,4 +101,100 @@ defmodule OpenBudget.Budgets do
   def change_account(%Account{} = account) do
     Account.changeset(account, %{})
   end
+
+  alias OpenBudget.Budgets.Budget
+
+  @doc """
+  Returns the list of budgets.
+
+  ## Examples
+
+      iex> list_budgets()
+      [%Budget{}, ...]
+
+  """
+  def list_budgets do
+    Repo.all(Budget)
+  end
+
+  @doc """
+  Gets a single budget.
+
+  Raises `Ecto.NoResultsError` if the Budget does not exist.
+
+  ## Examples
+
+      iex> get_budget!(123)
+      %Budget{}
+
+      iex> get_budget!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_budget!(id), do: Repo.get!(Budget, id)
+
+  @doc """
+  Creates a budget.
+
+  ## Examples
+
+      iex> create_budget(%{field: value})
+      {:ok, %Budget{}}
+
+      iex> create_budget(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_budget(attrs \\ %{}) do
+    %Budget{}
+    |> Budget.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a budget.
+
+  ## Examples
+
+      iex> update_budget(budget, %{field: new_value})
+      {:ok, %Budget{}}
+
+      iex> update_budget(budget, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_budget(%Budget{} = budget, attrs) do
+    budget
+    |> Budget.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Budget.
+
+  ## Examples
+
+      iex> delete_budget(budget)
+      {:ok, %Budget{}}
+
+      iex> delete_budget(budget)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_budget(%Budget{} = budget) do
+    Repo.delete(budget)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking budget changes.
+
+  ## Examples
+
+      iex> change_budget(budget)
+      %Ecto.Changeset{source: %Budget{}}
+
+  """
+  def change_budget(%Budget{} = budget) do
+    Budget.changeset(budget, %{})
+  end
 end

--- a/lib/open_budget/budgets/budgets.ex
+++ b/lib/open_budget/budgets/budgets.ex
@@ -7,6 +7,8 @@ defmodule OpenBudget.Budgets do
   alias OpenBudget.Repo
 
   alias OpenBudget.Budgets.Account
+  alias OpenBudget.Budgets.BudgetUser
+  alias OpenBudget.Authentication.User
 
   @doc """
   Returns the list of accounts.
@@ -196,5 +198,23 @@ defmodule OpenBudget.Budgets do
   """
   def change_budget(%Budget{} = budget) do
     Budget.changeset(budget, %{})
+  end
+
+  @doc """
+  Adds an association between a Budget and a User.
+
+  ## Examples
+      iex> associate_user_to_budget(budget, user)
+      [%OpenBudget.Authentication.User{}]
+  """
+  def associate_user_to_budget(%Budget{} = budget, %User{} = user) do
+    %BudgetUser{}
+    |> BudgetUser.changeset(%{budget_id: budget.id, user_id: user.id})
+    |> Repo.insert()
+    Repo.all(from u in User,
+            preload: [:budgets],
+            left_join: bu in BudgetUser, on: u.id == bu.user_id,
+            left_join: b in Budget, on: b.id == bu.budget_id,
+            where: b.id == ^budget.id)
   end
 end

--- a/lib/open_budget/guardian/auth_error_handler.ex
+++ b/lib/open_budget/guardian/auth_error_handler.ex
@@ -1,0 +1,11 @@
+defmodule OpenBudget.Guardian.AuthErrorHandler do
+  @moduledoc """
+  Handler required by Guardian pipeline
+  """
+  import Plug.Conn
+
+  def auth_error(conn, {type, reason}, _opts) do
+    body = Poison.encode!(%{message: to_string(type)})
+    send_resp(conn, 401, body)
+  end
+end

--- a/lib/open_budget/guardian/auth_error_handler.ex
+++ b/lib/open_budget/guardian/auth_error_handler.ex
@@ -2,10 +2,11 @@ defmodule OpenBudget.Guardian.AuthErrorHandler do
   @moduledoc """
   Handler required by Guardian pipeline
   """
-  import Plug.Conn
+  use OpenBudgetWeb, :controller
 
-  def auth_error(conn, {type, reason}, _opts) do
-    body = Poison.encode!(%{message: to_string(type)})
-    send_resp(conn, 401, body)
+  def auth_error(conn, _error, _opts) do
+    conn
+    |> put_status(401)
+    |> render(OpenBudgetWeb.ErrorView, "401.json-api")
   end
 end

--- a/lib/open_budget/guardian/auth_pipeline.ex
+++ b/lib/open_budget/guardian/auth_pipeline.ex
@@ -1,0 +1,15 @@
+defmodule OpenBudget.Guardian.AuthPipeline do
+  @moduledoc """
+  Pipeline for Guardian
+  """
+  alias OpenBudgetWeb.EnsureAuthenticatedController, as: EnsureAuthenticated
+  alias OpenBudget.Guardian.AuthErrorHandler
+
+  use Guardian.Plug.Pipeline, otp_app: :open_budget,
+                              module: OpenBudget.Authentication.Guardian,
+                              error_handler: AuthErrorHandler
+
+  plug Guardian.Plug.VerifyHeader, realm: "Bearer"
+  plug Guardian.Plug.EnsureAuthenticated, handler: EnsureAuthenticated
+  plug Guardian.Plug.LoadResource
+end

--- a/lib/open_budget_web/authentication.ex
+++ b/lib/open_budget_web/authentication.ex
@@ -35,7 +35,8 @@ defmodule OpenBudgetWeb.Authentication do
     end
   end
 
-  defp sign_in(conn, user) do
+  @doc false
+  def sign_in(conn, user) do
     conn
     |> Plug.sign_in(user)
   end

--- a/lib/open_budget_web/controllers/budget_controller.ex
+++ b/lib/open_budget_web/controllers/budget_controller.ex
@@ -1,0 +1,47 @@
+defmodule OpenBudgetWeb.BudgetController do
+  use OpenBudgetWeb, :controller
+
+  alias OpenBudget.Budgets
+  alias OpenBudget.Budgets.Budget
+  alias JaSerializer.Params
+
+  action_fallback OpenBudgetWeb.FallbackController
+
+  def index(conn, _params) do
+    budgets = Budgets.list_budgets()
+    render(conn, "index.json-api", data: budgets)
+  end
+
+  def create(conn, %{"data" => data}) do
+    attrs = Params.to_attributes(data)
+    with {:ok, %Budget{} = budget} <-
+        Budgets.create_budget(attrs) do
+      conn
+      |> put_status(:created)
+      |> put_resp_header("location", budget_path(conn, :show, budget))
+      |> render("show.json-api", data: budget)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    budget = Budgets.get_budget!(id)
+    render(conn, "show.json-api", data: budget)
+  end
+
+  def update(conn, %{"id" => id, "data" => data}) do
+    budget = Budgets.get_budget!(id)
+    attrs = Params.to_attributes(data)
+
+    with {:ok, %Budget{} = budget} <-
+        Budgets.update_budget(budget, attrs) do
+      render(conn, "show.json-api", data: budget)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    budget = Budgets.get_budget!(id)
+    with {:ok, %Budget{}} <- Budgets.delete_budget(budget) do
+      send_resp(conn, :no_content, "")
+    end
+  end
+end

--- a/lib/open_budget_web/router.ex
+++ b/lib/open_budget_web/router.ex
@@ -22,6 +22,7 @@ defmodule OpenBudgetWeb.Router do
 
     resources "/accounts", AccountController, except: [:new, :edit]
     resources "/users", UserController, except: [:new, :edit]
+    resources "/budgets", BudgetController, except: [:new, :edit]
   end
 
   scope "/api/auth", OpenBudgetWeb do

--- a/lib/open_budget_web/router.ex
+++ b/lib/open_budget_web/router.ex
@@ -18,6 +18,11 @@ defmodule OpenBudgetWeb.Router do
 
     resources "/accounts", AccountController, except: [:new, :edit]
     resources "/users", UserController, except: [:new, :edit]
+  end
+
+  scope "/api", OpenBudgetWeb do
+    pipe_through :api_auth
+
     resources "/budgets", BudgetController, except: [:new, :edit]
   end
 

--- a/lib/open_budget_web/router.ex
+++ b/lib/open_budget_web/router.ex
@@ -1,8 +1,6 @@
 defmodule OpenBudgetWeb.Router do
   use OpenBudgetWeb, :router
 
-  alias OpenBudgetWeb.EnsureAuthenticatedController, as: EnsureAuthenticated
-
   pipeline :api do
     plug :accepts, ["json-api"]
     plug JaSerializer.ContentTypeNegotiation
@@ -11,9 +9,7 @@ defmodule OpenBudgetWeb.Router do
 
   pipeline :api_auth do
     plug :accepts, ["json-api"]
-    plug Guardian.Plug.VerifyHeader, realm: "Bearer"
-    plug Guardian.Plug.EnsureAuthenticated, handler: EnsureAuthenticated
-    plug Guardian.Plug.LoadResource
+    plug OpenBudget.Guardian.AuthPipeline
     plug JaSerializer.Deserializer
   end
 

--- a/lib/open_budget_web/views/budget_view.ex
+++ b/lib/open_budget_web/views/budget_view.ex
@@ -1,0 +1,6 @@
+defmodule OpenBudgetWeb.BudgetView do
+  use OpenBudgetWeb, :view
+  use JaSerializer.PhoenixView
+
+  attributes [:name, :description]
+end

--- a/lib/open_budget_web/views/budget_view.ex
+++ b/lib/open_budget_web/views/budget_view.ex
@@ -2,5 +2,14 @@ defmodule OpenBudgetWeb.BudgetView do
   use OpenBudgetWeb, :view
   use JaSerializer.PhoenixView
 
+  location "/budgets/:id"
   attributes [:name, :description]
+
+  has_many :users,
+    serializer: OpenBudgetWeb.UserView,
+    include: false,
+    identifiers: :when_included,
+    links: [
+      related: "/budgets/:id/users"
+    ]
 end

--- a/priv/repo/migrations/20171015122444_create_budgets.exs
+++ b/priv/repo/migrations/20171015122444_create_budgets.exs
@@ -1,0 +1,13 @@
+defmodule OpenBudget.Repo.Migrations.CreateBudgets do
+  use Ecto.Migration
+
+  def change do
+    create table(:budgets) do
+      add :name, :string
+      add :description, :string
+
+      timestamps()
+    end
+
+  end
+end

--- a/priv/repo/migrations/20171019153131_add_budget_user_join_reference.exs
+++ b/priv/repo/migrations/20171019153131_add_budget_user_join_reference.exs
@@ -1,0 +1,12 @@
+defmodule OpenBudget.Repo.Migrations.AddBudgetUserJoinReference do
+  use Ecto.Migration
+
+  def change do
+    create table(:budgets_users, primary_key: false) do
+      add :budget_id, references(:budgets)
+      add :user_id, references(:users)
+    end
+
+    create unique_index(:budgets_users, [:budget_id, :user_id])
+  end
+end

--- a/test/open_budget/budgets/budgets_test.exs
+++ b/test/open_budget/budgets/budgets_test.exs
@@ -2,6 +2,7 @@ defmodule OpenBudget.BudgetsTest do
   use OpenBudget.DataCase
 
   alias OpenBudget.Budgets
+  alias OpenBudget.Authentication
 
   describe "accounts" do
     alias OpenBudget.Budgets.Account
@@ -83,6 +84,15 @@ defmodule OpenBudget.BudgetsTest do
       budget
     end
 
+    def user_fixture(attrs \\ %{}) do
+      {:ok, user} =
+        attrs
+        |> Enum.into(%{email: "test@example.com", password: "password"})
+        |> Authentication.create_user()
+
+      user
+    end
+
     test "list_budgets/0 returns all budgets" do
       budget = budget_fixture()
       assert Budgets.list_budgets() == [budget]
@@ -126,6 +136,26 @@ defmodule OpenBudget.BudgetsTest do
     test "change_budget/1 returns a budget changeset" do
       budget = budget_fixture()
       assert %Ecto.Changeset{} = Budgets.change_budget(budget)
+    end
+
+    test "associate_user_to_budget/2 associates a user to a budget" do
+      budget = budget_fixture()
+      user = user_fixture()
+      result = Budgets.associate_user_to_budget(budget, user)
+      user_result = hd(result)
+      assert Kernel.length(result) == 1
+      assert user_result.email == "test@example.com"
+    end
+
+    test "associate_user_to_budget/2 associates a user to a budget with an existing user association" do
+      budget = budget_fixture()
+      existing_user = user_fixture(%{email: "existing@example.com", password: "existingpassword"})
+      user = user_fixture()
+      Budgets.associate_user_to_budget(budget, existing_user)
+      result = Budgets.associate_user_to_budget(budget, user)
+      user_result = hd(result)
+      assert Kernel.length(result) == 2
+      assert user_result.email == "existing@example.com"
     end
   end
 end

--- a/test/open_budget/budgets/budgets_test.exs
+++ b/test/open_budget/budgets/budgets_test.exs
@@ -66,4 +66,66 @@ defmodule OpenBudget.BudgetsTest do
       assert %Ecto.Changeset{} = Budgets.change_account(account)
     end
   end
+
+  describe "budgets" do
+    alias OpenBudget.Budgets.Budget
+
+    @valid_attrs %{name: "Sample Budget", description: "This is a sample budget"}
+    @update_attrs %{name: "Updated Sample Budget", description: "This is an updated sample budget"}
+    @invalid_attrs %{name: nil, description: nil}
+
+    def budget_fixture(attrs \\ %{}) do
+      {:ok, budget} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Budgets.create_budget()
+
+      budget
+    end
+
+    test "list_budgets/0 returns all budgets" do
+      budget = budget_fixture()
+      assert Budgets.list_budgets() == [budget]
+    end
+
+    test "get_budget!/1 returns the budget with given id" do
+      budget = budget_fixture()
+      assert Budgets.get_budget!(budget.id) == budget
+    end
+
+    test "create_budget/1 with valid data creates a budget" do
+      assert {:ok, %Budget{} = budget} = Budgets.create_budget(@valid_attrs)
+      assert budget.name == "Sample Budget"
+      assert budget.description == "This is a sample budget"
+    end
+
+    test "create_budget/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Budgets.create_budget(@invalid_attrs)
+    end
+
+    test "update_budget/2 with valid data updates the budget" do
+      budget = budget_fixture()
+      assert {:ok, budget} = Budgets.update_budget(budget, @update_attrs)
+      assert %Budget{} = budget
+      assert budget.name == "Updated Sample Budget"
+      assert budget.description == "This is an updated sample budget"
+    end
+
+    test "update_budget/2 with invalid data returns error changeset" do
+      budget = budget_fixture()
+      assert {:error, %Ecto.Changeset{}} = Budgets.update_budget(budget, @invalid_attrs)
+      assert budget == Budgets.get_budget!(budget.id)
+    end
+
+    test "delete_budget/1 deletes the budget" do
+      budget = budget_fixture()
+      assert {:ok, %Budget{}} = Budgets.delete_budget(budget)
+      assert_raise Ecto.NoResultsError, fn -> Budgets.get_budget!(budget.id) end
+    end
+
+    test "change_budget/1 returns a budget changeset" do
+      budget = budget_fixture()
+      assert %Ecto.Changeset{} = Budgets.change_budget(budget)
+    end
+  end
 end

--- a/test/open_budget/guardian/auth_error_handler_test.exs
+++ b/test/open_budget/guardian/auth_error_handler_test.exs
@@ -1,0 +1,14 @@
+defmodule OpenBudget.Guardian.AuthErrorHandlerTest do
+  use OpenBudgetWeb.ConnCase
+
+  alias OpenBudget.Guardian.AuthErrorHandler
+
+  describe("#auth_error") do
+    test "sends 401 resp with {message: <type>} json as body", %{conn: conn} do
+      conn = AuthErrorHandler.auth_error(conn, {:unauthorized, nil}, nil)
+
+      assert conn.status == 401
+      assert conn.resp_body == Poison.encode!(%{message: "unauthorized"})
+    end
+  end
+end

--- a/test/open_budget/guardian/auth_error_handler_test.exs
+++ b/test/open_budget/guardian/auth_error_handler_test.exs
@@ -6,9 +6,10 @@ defmodule OpenBudget.Guardian.AuthErrorHandlerTest do
   describe("#auth_error") do
     test "sends 401 resp with {message: <type>} json as body", %{conn: conn} do
       conn = AuthErrorHandler.auth_error(conn, {:unauthorized, nil}, nil)
+      resp_body = Poison.encode!(%{jsonapi: %{version: "1.0"}, errors: [%{title: "Unauthorized", code: 401}]})
 
       assert conn.status == 401
-      assert conn.resp_body == Poison.encode!(%{message: "unauthorized"})
+      assert conn.resp_body == resp_body
     end
   end
 end

--- a/test/open_budget_web/controllers/budget_controller_test.exs
+++ b/test/open_budget_web/controllers/budget_controller_test.exs
@@ -1,0 +1,95 @@
+defmodule OpenBudgetWeb.BudgetControllerTest do
+  use OpenBudgetWeb.ConnCase
+
+  alias OpenBudget.Budgets
+  alias OpenBudget.Budgets.Budget
+
+  @create_attrs %{name: "Sample Budget", description: "This is a sample budget"}
+  @update_attrs %{name: "Updated Sample Budget", description: "This is an updated sample budget"}
+  @invalid_attrs %{name: nil, description: nil}
+
+  def fixture(:budget) do
+    {:ok, budget} = Budgets.create_budget(@create_attrs)
+    budget
+  end
+
+  setup %{conn: conn} do
+    conn =
+      conn
+      |> put_req_header("accept", "application/vnd.api+json")
+      |> put_req_header("content-type", "application/vnd.api+json")
+
+    {:ok, conn: conn}
+  end
+
+  describe "index" do
+    test "lists all budgets", %{conn: conn} do
+      conn = get conn, budget_path(conn, :index)
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create budget" do
+    test "renders budget when data is valid", %{conn: conn} do
+      params = Poison.encode!(%{data: %{attributes: @create_attrs}})
+      conn = post conn, budget_path(conn, :create), params
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get conn, budget_path(conn, :show, id)
+      assert json_response(conn, 200)["data"] == %{
+        "type" => "budget",
+        "id" => "#{id}",
+        "attributes" => %{
+          "name" => "Sample Budget",
+          "description" => "This is a sample budget"
+        }
+      }
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      params = %{data: %{attributes: @invalid_attrs}}
+      conn = post conn, budget_path(conn, :create), params
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update budget" do
+    setup [:create_budget]
+
+    test "renders budget when data is valid", %{conn: conn, budget: %Budget{id: id} = budget} do
+      params = Poison.encode!(%{data: %{attributes: @update_attrs}})
+      conn = put conn, budget_path(conn, :update, budget), params
+      assert json_response(conn, 200)["data"] == %{
+        "type" => "budget",
+        "id" => "#{id}",
+        "attributes" => %{
+          "name" => "Updated Sample Budget",
+          "description" => "This is an updated sample budget"
+        }
+      }
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, budget: budget} do
+      params = %{data: %{attributes: @invalid_attrs}}
+      conn = put conn, budget_path(conn, :update, budget), params
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete budget" do
+    setup [:create_budget]
+
+    test "deletes chosen budget", %{conn: conn, budget: budget} do
+      conn = delete conn, budget_path(conn, :delete, budget)
+      assert response(conn, 204)
+      assert_error_sent 404, fn ->
+        get conn, budget_path(conn, :show, budget)
+      end
+    end
+  end
+
+  defp create_budget(_) do
+    budget = fixture(:budget)
+    {:ok, budget: budget}
+  end
+end


### PR DESCRIPTION
This finishes #6 and #7.

Changes include the following:

- Add Budgets schema
- Add Budgets API endpoints
  - `GET /budgets`
  - `GET /budgets/:id`
  - `POST /budgets`
  - `PATCH /budgets/:id`
  - `DELETE /budgets/:id`
- Associate Budgets and Users resource.