### PR TITLE
Require authentication for User endpoints except create

### DIFF
--- a/lib/open_budget_web/controllers/user_controller.ex
+++ b/lib/open_budget_web/controllers/user_controller.ex
@@ -18,7 +18,6 @@ defmodule OpenBudgetWeb.UserController do
         Authentication.create_user(attrs) do
       conn
       |> put_status(:created)
-      |> put_resp_header("location", user_path(conn, :show, user))
       |> render("show.json-api", data: user)
     end
   end

--- a/lib/open_budget_web/router.ex
+++ b/lib/open_budget_web/router.ex
@@ -17,13 +17,14 @@ defmodule OpenBudgetWeb.Router do
     pipe_through :api
 
     resources "/accounts", AccountController, except: [:new, :edit]
-    resources "/users", UserController, except: [:new, :edit]
+    resources "/users", UserController, only: [:create]
   end
 
   scope "/api", OpenBudgetWeb do
     pipe_through :api_auth
 
     resources "/budgets", BudgetController, except: [:new, :edit]
+    resources "/users", UserController, except: [:new, :edit, :create]
   end
 
   scope "/api/auth", OpenBudgetWeb do

--- a/lib/open_budget_web/views/user_view.ex
+++ b/lib/open_budget_web/views/user_view.ex
@@ -2,5 +2,6 @@ defmodule OpenBudgetWeb.UserView do
   use OpenBudgetWeb, :view
   use JaSerializer.PhoenixView
 
+  location "/users/:id"
   attributes [:email]
 end

--- a/test/open_budget_web/controllers/user_controller_test.exs
+++ b/test/open_budget_web/controllers/user_controller_test.exs
@@ -42,10 +42,16 @@ defmodule OpenBudgetWeb.UserControllerTest do
         conn
         |> WebAuth.sign_in(user)
         |> get(user_path(conn, :show, user.id))
-      response = json_response(conn, 200)["data"]
 
-      assert response["attributes"] == %{
-        "email" => "test@example.com"
+      assert json_response(conn, 200)["data"] == %{
+        "type" => "user",
+        "id" => "#{user.id}",
+        "attributes" => %{
+          "email" => "test@example.com"
+        },
+        "links" => %{
+          "self" => "/users/#{user.id}"
+        }
       }
     end
   end

--- a/test/open_budget_web/controllers/user_controller_test.exs
+++ b/test/open_budget_web/controllers/user_controller_test.exs
@@ -3,6 +3,7 @@ defmodule OpenBudgetWeb.UserControllerTest do
 
   alias OpenBudget.Authentication
   alias OpenBudget.Authentication.User
+  alias OpenBudgetWeb.Authentication, as: WebAuth
 
   @create_attrs %{email: "test@example.com", password: "secretpassword"}
   @update_attrs %{email: "updated@example.com", password: "updatedsecretpassword"}
@@ -24,8 +25,13 @@ defmodule OpenBudgetWeb.UserControllerTest do
 
   describe "index" do
     test "lists all users", %{conn: conn} do
-      conn = get conn, user_path(conn, :index)
-      assert json_response(conn, 200)["data"] == []
+      user = fixture(:user)
+      conn =
+        conn
+        |> WebAuth.sign_in(user)
+        |> get(user_path(conn, :index))
+
+      assert length(json_response(conn, 200)["data"]) == 1
     end
   end
 
@@ -33,15 +39,10 @@ defmodule OpenBudgetWeb.UserControllerTest do
     test "renders user when data is valid", %{conn: conn} do
       params = Poison.encode!(%{data: %{attributes: @create_attrs}})
       conn = post conn, user_path(conn, :create), params
-      assert %{"id" => id} = json_response(conn, 201)["data"]
+      response = json_response(conn, 201)["data"]
 
-      conn = get conn, user_path(conn, :show, id)
-      assert json_response(conn, 200)["data"] == %{
-        "type" => "user",
-        "id" => id,
-        "attributes" => %{
-          "email" => "test@example.com"
-        }
+      assert response["attributes"] == %{
+        "email" => "test@example.com"
       }
     end
 
@@ -55,21 +56,25 @@ defmodule OpenBudgetWeb.UserControllerTest do
   describe "update user" do
     setup [:create_user]
 
-    test "renders user when data is valid", %{conn: conn, user: %User{id: id} = user} do
+    test "renders user when data is valid", %{conn: conn, user: %User{id: _id} = user} do
       params = Poison.encode!(%{data: %{attributes: @update_attrs}})
-      conn = put conn, user_path(conn, :update, user), params
-      assert json_response(conn, 200)["data"] == %{
-        "type" => "user",
-        "id" => "#{id}",
-        "attributes" => %{
-          "email" => "updated@example.com"
-        }
+      conn =
+        conn
+        |> WebAuth.sign_in(user)
+        |> put(user_path(conn, :update, user), params)
+      response = json_response(conn, 200)["data"]
+
+      assert response["attributes"] == %{
+        "email" => "updated@example.com"
       }
     end
 
     test "renders errors when data is invalid", %{conn: conn, user: user} do
       params = %{data: %{attributes: @invalid_attrs}}
-      conn = put conn, user_path(conn, :update, user), params
+      conn =
+        conn
+        |> WebAuth.sign_in(user)
+        |> put(user_path(conn, :update, user), params)
       assert json_response(conn, 422)["errors"] != %{}
     end
   end
@@ -78,11 +83,11 @@ defmodule OpenBudgetWeb.UserControllerTest do
     setup [:create_user]
 
     test "deletes chosen user", %{conn: conn, user: user} do
-      conn = delete conn, user_path(conn, :delete, user)
+      conn =
+        conn
+        |> WebAuth.sign_in(user)
+        |> delete(user_path(conn, :delete, user))
       assert response(conn, 204)
-      assert_error_sent 404, fn ->
-        get conn, user_path(conn, :show, user)
-      end
     end
   end
 

--- a/test/open_budget_web/controllers/user_controller_test.exs
+++ b/test/open_budget_web/controllers/user_controller_test.exs
@@ -35,6 +35,21 @@ defmodule OpenBudgetWeb.UserControllerTest do
     end
   end
 
+  describe "show" do
+    test "display a user", %{conn: conn} do
+      user = fixture(:user)
+      conn =
+        conn
+        |> WebAuth.sign_in(user)
+        |> get(user_path(conn, :show, user.id))
+      response = json_response(conn, 200)["data"]
+
+      assert response["attributes"] == %{
+        "email" => "test@example.com"
+      }
+    end
+  end
+
   describe "create user" do
     test "renders user when data is valid", %{conn: conn} do
       params = Poison.encode!(%{data: %{attributes: @create_attrs}})


### PR DESCRIPTION
This closes #11.

This PR adds a requirement for user authentication for the following routes:

- `GET /users`
- `GET /users/:id`
- `PATCH /users/:id`
- `DELETE /users/:id`