### PR TITLE
Refactor Budgets resource

### DIFF
--- a/lib/open_budget/budgets/budget.ex
+++ b/lib/open_budget/budgets/budget.ex
@@ -11,7 +11,10 @@ defmodule OpenBudget.Budgets.Budget do
   schema "budgets" do
     field :description, :string
     field :name, :string
-    many_to_many :users, User, join_through: BudgetUser, unique: true
+    many_to_many :users, User,
+                       join_through: BudgetUser,
+                       unique: true,
+                       on_delete: :delete_all
 
     timestamps()
   end

--- a/lib/open_budget/budgets/budgets.ex
+++ b/lib/open_budget/budgets/budgets.ex
@@ -120,6 +120,22 @@ defmodule OpenBudget.Budgets do
   end
 
   @doc """
+  Returns the list of budgets associated with the user specified.
+
+  ## Examples
+
+      iex> list_budgets(user)
+      [%Budget{}, ...]
+
+  """
+  def list_budgets(user) do
+    Repo.all(from b in Budget,
+            left_join: bu in BudgetUser, on: b.id == bu.budget_id,
+            left_join: u in User, on: u.id == bu.user_id,
+            where: u.id == ^user.id)
+  end
+
+  @doc """
   Gets a single budget.
 
   Raises `Ecto.NoResultsError` if the Budget does not exist.

--- a/lib/open_budget/budgets/budgets.ex
+++ b/lib/open_budget/budgets/budgets.ex
@@ -138,18 +138,21 @@ defmodule OpenBudget.Budgets do
   @doc """
   Gets a single budget.
 
-  Raises `Ecto.NoResultsError` if the Budget does not exist.
-
   ## Examples
 
-      iex> get_budget!(123)
-      %Budget{}
+      iex> get_budget(123)
+      {:ok, %Budget{}}
 
-      iex> get_budget!(456)
-      ** (Ecto.NoResultsError)
+      iex> get_budget(456)
+      {:error, "Budget not found"}
 
   """
-  def get_budget!(id), do: Repo.get!(Budget, id)
+  def get_budget(id) do
+    budget = Repo.get!(Budget, id)
+    {:ok, budget}
+  rescue
+    Ecto.NoResultsError -> {:error, "Budget not found"}
+  end
 
   @doc """
   Gets a single budget that's associated with the given user.
@@ -158,18 +161,21 @@ defmodule OpenBudget.Budgets do
 
   ## Examples
 
-      iex> get_budget!(123, user)
-      %Budget{}
+      iex> get_budget(123, user)
+      {:ok, %Budget{}}
 
-      iex> get_budget!(456, user)
-      ** (Ecto.NoResultsError)
+      iex> get_budget(456, user)
+      {:error, "Budget not found"}
 
   """
-  def get_budget!(id, user) do
-    Repo.one!(from b in Budget,
-             left_join: bu in BudgetUser, on: b.id == bu.budget_id,
-             left_join: u in User, on: u.id == bu.user_id,
-             where: u.id == ^user.id and b.id == ^id)
+  def get_budget(id, user) do
+    budget = Repo.one!(from b in Budget,
+                      left_join: bu in BudgetUser, on: b.id == bu.budget_id,
+                      left_join: u in User, on: u.id == bu.user_id,
+                      where: u.id == ^user.id and b.id == ^id)
+    {:ok, budget}
+  rescue
+    Ecto.NoResultsError -> {:error, "Budget not found"}
   end
 
   @doc """

--- a/lib/open_budget/budgets/budgets.ex
+++ b/lib/open_budget/budgets/budgets.ex
@@ -196,6 +196,18 @@ defmodule OpenBudget.Budgets do
     |> Repo.insert()
   end
 
+  @doc """
+  Creates a budget and associate it with the given user.
+
+  ## Examples
+
+      iex> create_budget(%{field: value}, user)
+      {:ok, %Budget{}}
+
+      iex> create_budget(%{field: bad_value}, user)
+      {:error, %Ecto.Changeset{}}
+
+  """
   def create_budget(attrs, user) do
     changeset =
       %Budget{}

--- a/lib/open_budget/budgets/budgets.ex
+++ b/lib/open_budget/budgets/budgets.ex
@@ -196,6 +196,22 @@ defmodule OpenBudget.Budgets do
     |> Repo.insert()
   end
 
+  def create_budget(attrs, user) do
+    changeset =
+      %Budget{}
+      |> Budget.changeset(attrs)
+      |> Repo.insert()
+
+    case changeset do
+      {:ok, budget} ->
+        associate_user_to_budget(budget, user)
+        budget = Repo.preload(budget, :users)
+        {:ok, budget}
+      {:error, bad_changeset} ->
+        {:error, bad_changeset}
+    end
+  end
+
   @doc """
   Updates a budget.
 

--- a/lib/open_budget/budgets/budgets.ex
+++ b/lib/open_budget/budgets/budgets.ex
@@ -152,6 +152,27 @@ defmodule OpenBudget.Budgets do
   def get_budget!(id), do: Repo.get!(Budget, id)
 
   @doc """
+  Gets a single budget that's associated with the given user.
+
+  Raises `Ecto.NoResultsError` if the Budget does not exist.
+
+  ## Examples
+
+      iex> get_budget!(123, user)
+      %Budget{}
+
+      iex> get_budget!(456, user)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_budget!(id, user) do
+    Repo.one!(from b in Budget,
+             left_join: bu in BudgetUser, on: b.id == bu.budget_id,
+             left_join: u in User, on: u.id == bu.user_id,
+             where: u.id == ^user.id and b.id == ^id)
+  end
+
+  @doc """
   Creates a budget.
 
   ## Examples

--- a/lib/open_budget_web/controllers/budget_controller.ex
+++ b/lib/open_budget_web/controllers/budget_controller.ex
@@ -10,7 +10,8 @@ defmodule OpenBudgetWeb.BudgetController do
   action_fallback OpenBudgetWeb.FallbackController
 
   def index(conn, _params) do
-    budgets = Budgets.list_budgets()
+    current_user = Plug.current_resource(conn)
+    budgets = Budgets.list_budgets(current_user)
     render(conn, "index.json-api", data: budgets)
   end
 

--- a/lib/open_budget_web/controllers/budget_controller.ex
+++ b/lib/open_budget_web/controllers/budget_controller.ex
@@ -33,8 +33,14 @@ defmodule OpenBudgetWeb.BudgetController do
   end
 
   def show(conn, %{"id" => id}) do
-    budget = Budgets.get_budget!(id)
+    current_user = Plug.current_resource(conn)
+    budget = Budgets.get_budget!(id, current_user)
     render(conn, "show.json-api", data: budget)
+  rescue
+    Ecto.NoResultsError ->
+      conn
+      |> put_status(404)
+      |> render(OpenBudgetWeb.ErrorView, "404.json-api")
   end
 
   def update(conn, %{"id" => id, "data" => data}) do

--- a/test/open_budget/budgets/budgets_test.exs
+++ b/test/open_budget/budgets/budgets_test.exs
@@ -110,6 +110,21 @@ defmodule OpenBudget.BudgetsTest do
       assert Budgets.get_budget!(budget.id) == budget
     end
 
+    test "get_budget!/2 returns the budget with given id and associated user" do
+      user = user_fixture()
+      budget = budget_fixture()
+      Budgets.associate_user_to_budget(budget, user)
+      assert Budgets.get_budget!(budget.id, user) == budget
+    end
+
+    test "get_budget!/2 with invalid budget and user association returns nothing" do
+      user = user_fixture()
+      budget = budget_fixture()
+      assert_raise Ecto.NoResultsError, fn ->
+        Budgets.get_budget!(budget.id, user)
+      end
+    end
+
     test "create_budget/1 with valid data creates a budget" do
       assert {:ok, %Budget{} = budget} = Budgets.create_budget(@valid_attrs)
       assert budget.name == "Sample Budget"

--- a/test/open_budget/budgets/budgets_test.exs
+++ b/test/open_budget/budgets/budgets_test.exs
@@ -137,6 +137,18 @@ defmodule OpenBudget.BudgetsTest do
       assert {:error, %Ecto.Changeset{}} = Budgets.create_budget(@invalid_attrs)
     end
 
+    test "create_budget/2 with valid data creates a budget" do
+      user = user_fixture()
+      assert {:ok, %Budget{} = budget} = Budgets.create_budget(@valid_attrs, user)
+      assert budget.name == "Sample Budget"
+      assert budget.description == "This is a sample budget"
+    end
+
+    test "create_budget/2 with invalid data returns error changeset" do
+      user = user_fixture()
+      assert {:error, %Ecto.Changeset{}} = Budgets.create_budget(@invalid_attrs, user)
+    end
+
     test "update_budget/2 with valid data updates the budget" do
       budget = budget_fixture()
       assert {:ok, budget} = Budgets.update_budget(budget, @update_attrs)

--- a/test/open_budget/budgets/budgets_test.exs
+++ b/test/open_budget/budgets/budgets_test.exs
@@ -105,24 +105,26 @@ defmodule OpenBudget.BudgetsTest do
       assert Budgets.list_budgets(user) == [budget]
     end
 
-    test "get_budget!/1 returns the budget with given id" do
+    test "get_budget/1 returns the budget with given id" do
       budget = budget_fixture()
-      assert Budgets.get_budget!(budget.id) == budget
+      assert Budgets.get_budget(budget.id) == {:ok, budget}
     end
 
-    test "get_budget!/2 returns the budget with given id and associated user" do
+    test "get_budget/1 with invalid budget returns nothing" do
+      assert Budgets.get_budget(123) == {:error, "Budget not found"}
+    end
+
+    test "get_budget/2 returns the budget with given id and associated user" do
       user = user_fixture()
       budget = budget_fixture()
       Budgets.associate_user_to_budget(budget, user)
-      assert Budgets.get_budget!(budget.id, user) == budget
+      assert Budgets.get_budget(budget.id, user) == {:ok, budget}
     end
 
-    test "get_budget!/2 with invalid budget and user association returns nothing" do
+    test "get_budget/2 with invalid budget and user association returns nothing" do
       user = user_fixture()
       budget = budget_fixture()
-      assert_raise Ecto.NoResultsError, fn ->
-        Budgets.get_budget!(budget.id, user)
-      end
+      assert Budgets.get_budget(budget.id, user) == {:error, "Budget not found"}
     end
 
     test "create_budget/1 with valid data creates a budget" do
@@ -146,13 +148,13 @@ defmodule OpenBudget.BudgetsTest do
     test "update_budget/2 with invalid data returns error changeset" do
       budget = budget_fixture()
       assert {:error, %Ecto.Changeset{}} = Budgets.update_budget(budget, @invalid_attrs)
-      assert budget == Budgets.get_budget!(budget.id)
+      assert {:ok, budget} == Budgets.get_budget(budget.id)
     end
 
     test "delete_budget/1 deletes the budget" do
       budget = budget_fixture()
       assert {:ok, %Budget{}} = Budgets.delete_budget(budget)
-      assert_raise Ecto.NoResultsError, fn -> Budgets.get_budget!(budget.id) end
+      assert Budgets.get_budget(budget.id) == {:error, "Budget not found"}
     end
 
     test "change_budget/1 returns a budget changeset" do

--- a/test/open_budget/budgets/budgets_test.exs
+++ b/test/open_budget/budgets/budgets_test.exs
@@ -98,6 +98,13 @@ defmodule OpenBudget.BudgetsTest do
       assert Budgets.list_budgets() == [budget]
     end
 
+    test "list_budgets/1 returns all budgets associated with the user" do
+      user = user_fixture()
+      budget = budget_fixture()
+      Budgets.associate_user_to_budget(budget, user)
+      assert Budgets.list_budgets(user) == [budget]
+    end
+
     test "get_budget!/1 returns the budget with given id" do
       budget = budget_fixture()
       assert Budgets.get_budget!(budget.id) == budget

--- a/test/open_budget_web/controllers/budget_controller_test.exs
+++ b/test/open_budget_web/controllers/budget_controller_test.exs
@@ -42,8 +42,9 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
 
   describe "index" do
     test "lists all budgets", %{conn: conn} do
+      budget_fixture()
       conn = get conn, budget_path(conn, :index)
-      assert json_response(conn, 200)["data"] == []
+      assert length(json_response(conn, 200)["data"]) == 1
     end
   end
 

--- a/test/open_budget_web/controllers/budget_controller_test.exs
+++ b/test/open_budget_web/controllers/budget_controller_test.exs
@@ -122,7 +122,7 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
   describe "update budget" do
     setup [:create_budget]
 
-    test "renders budget when data is valid", %{conn: conn, budget: %Budget{id: _id} = budget} do
+    test "renders budget when data is valid", %{conn: conn, budget: budget} do
       user = Repo.get_by(User, email: "test@example.com")
       Budgets.associate_user_to_budget(budget, user)
 
@@ -138,9 +138,23 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
     end
 
     test "renders errors when data is invalid", %{conn: conn, budget: budget} do
+      user = Repo.get_by(User, email: "test@example.com")
+      Budgets.associate_user_to_budget(budget, user)
       params = %{data: %{attributes: @invalid_attrs}}
       conn = put conn, budget_path(conn, :update, budget), params
-      assert json_response(conn, 422)["errors"] != %{}
+      assert json_response(conn, 422)["errors"] == [%{
+        "title" => "Unprocessable entity",
+        "code" => 422
+      }]
+    end
+
+    test "renders error when budget is not associated with current user", %{conn: conn, budget: budget} do
+      params = %{data: %{attributes: @update_attrs}}
+      conn = put conn, budget_path(conn, :update, budget), params
+      assert json_response(conn, 404)["errors"] == [%{
+        "title" => "Resource not found",
+        "code" => 404
+      }]
     end
   end
 

--- a/test/open_budget_web/controllers/budget_controller_test.exs
+++ b/test/open_budget_web/controllers/budget_controller_test.exs
@@ -3,7 +3,6 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
 
   alias OpenBudget.Repo
   alias OpenBudget.Budgets
-  alias OpenBudget.Budgets.Budget
   alias OpenBudget.Authentication
   alias OpenBudget.Authentication.User
   alias OpenBudgetWeb.Authentication, as: WebAuth
@@ -115,7 +114,10 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
     test "renders errors when data is invalid", %{conn: conn} do
       params = %{data: %{attributes: @invalid_attrs}}
       conn = post conn, budget_path(conn, :create), params
-      assert json_response(conn, 422)["errors"] != %{}
+      assert json_response(conn, 422)["errors"] == [%{
+        "title" => "Unprocessable entity",
+        "code" => 422
+      }]
     end
   end
 

--- a/test/open_budget_web/controllers/budget_controller_test.exs
+++ b/test/open_budget_web/controllers/budget_controller_test.exs
@@ -42,8 +42,20 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
 
   describe "index" do
     test "lists all budgets", %{conn: conn} do
-      budget_fixture()
+      user = Repo.get_by(User, %{email: "test@example.com"})
+      budget = budget_fixture()
+      Budgets.associate_user_to_budget(budget, user)
       conn = get conn, budget_path(conn, :index)
+      assert length(json_response(conn, 200)["data"]) == 1
+    end
+
+    test "list only budgets associated to the user", %{conn: conn} do
+      user = Repo.get_by(User, %{email: "test@example.com"})
+      budget_fixture()
+      budget = budget_fixture(%{name: "Associated Budget", category: "Cash"})
+      Budgets.associate_user_to_budget(budget, user)
+      conn = get conn, budget_path(conn, :index)
+
       assert length(json_response(conn, 200)["data"]) == 1
     end
   end

--- a/test/open_budget_web/controllers/budget_controller_test.exs
+++ b/test/open_budget_web/controllers/budget_controller_test.exs
@@ -12,18 +12,24 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
   @update_attrs %{name: "Updated Sample Budget", description: "This is an updated sample budget"}
   @invalid_attrs %{name: nil, description: nil}
 
-  def fixture(:budget) do
-    {:ok, budget} = Budgets.create_budget(@create_attrs)
+  def budget_fixture(attrs \\ %{}) do
+    {:ok, budget} =
+      attrs
+      |> Enum.into(@create_attrs)
+      |> Budgets.create_budget()
     budget
   end
 
-  def fixture(:user) do
-    {:ok, user} = Authentication.create_user(%{email: "test@example.com", password: "password"})
+  def user_fixture(attrs \\ %{}) do
+    {:ok, user} =
+      attrs
+      |> Enum.into(%{email: "test@example.com", password: "password"})
+      |> Authentication.create_user()
     user
   end
 
   setup %{conn: conn} do
-    user = fixture(:user)
+    user = user_fixture()
 
     conn =
       conn
@@ -96,7 +102,7 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
   end
 
   defp create_budget(_) do
-    budget = fixture(:budget)
+    budget = budget_fixture()
     {:ok, budget: budget}
   end
 end

--- a/test/open_budget_web/controllers/budget_controller_test.exs
+++ b/test/open_budget_web/controllers/budget_controller_test.exs
@@ -162,8 +162,18 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
     setup [:create_budget]
 
     test "deletes chosen budget", %{conn: conn, budget: budget} do
+      user = Repo.get_by(User, email: "test@example.com")
+      Budgets.associate_user_to_budget(budget, user)
       conn = delete conn, budget_path(conn, :delete, budget)
       assert response(conn, 204)
+    end
+
+    test "renders error when budget is not associated with current user", %{conn: conn, budget: budget} do
+      conn = delete conn, budget_path(conn, :delete, budget)
+      assert json_response(conn, 404)["errors"] == [%{
+        "title" => "Resource not found",
+        "code" => 404
+      }]
     end
   end
 


### PR DESCRIPTION
This is a redo of #16.

These changes should have been part of #7.

This PR changes the Budgets endpoint to take into account the current user.