### PR TITLE
Make coveralls ignore automatically-generated files

### DIFF
--- a/coveralls.json
+++ b/coveralls.json
@@ -1,6 +1,10 @@
 {
   "skip_files": [
     "test",
-    "lib/open_budget/guardian.ex"
+    "lib/open_budget_web.ex",
+    "lib/open_budget_web/endpoint.ex",
+    "lib/open_budget_web/controllers/fallback_controller.ex",
+    "lib/open_budget_web/views/error_helpers.ex",
+    "lib/open_budget/application.ex"
   ]
 }


### PR DESCRIPTION
There are some files that are preventing us from achieving 100% code coverage. A few of them are from the code that we've written, but the rest of them came from the code that was generated automatically.

With that said, I think it's safe to ignore them since they most likely have been tested as part of Phoenix's test suite.