### PR TITLE
Add Travis integration for core room in Gitter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/4ecd75f033a429fcd86e
+      - https://webhooks.gitter.im/e/caeaec0234a8ec76cd88
     on_success: change
     on_failure: always
     on_start: never


### PR DESCRIPTION
We have a Lobby room in Gitter as the catch all, but we also need to add an integration for the dedicated room for core.