### PR TITLE
Better Error Responses

### DIFF
--- a/lib/open_budget_web/controllers/budget_controller.ex
+++ b/lib/open_budget_web/controllers/budget_controller.ex
@@ -22,10 +22,10 @@ defmodule OpenBudgetWeb.BudgetController do
         conn
         |> put_status(201)
         |> render("show.json-api", data: budget, opts: [include: "users"])
-      {:error, _} ->
+      {:error, changeset} ->
         conn
         |> put_status(422)
-        |> render(OpenBudgetWeb.ErrorView, "422.json-api")
+        |> render(OpenBudgetWeb.ErrorView, "422.json-api", changeset: changeset)
     end
   end
 
@@ -49,10 +49,10 @@ defmodule OpenBudgetWeb.BudgetController do
 
         case Budgets.update_budget(budget, attrs) do
           {:ok, budget} -> render(conn, "show.json-api", data: budget, opts: [include: "users"])
-          {:error, _} ->
+          {:error, changeset} ->
             conn
             |> put_status(422)
-            |> render(OpenBudgetWeb.ErrorView, "422.json-api")
+            |> render(OpenBudgetWeb.ErrorView, "422.json-api", changeset: changeset)
         end
       {:error, _} ->
         conn

--- a/lib/open_budget_web/views/error_view.ex
+++ b/lib/open_budget_web/views/error_view.ex
@@ -3,6 +3,7 @@ defmodule OpenBudgetWeb.ErrorView do
   use JaSerializer.PhoenixView
 
   alias JaSerializer.ErrorSerializer
+  alias JaSerializer.EctoErrorSerializer
 
   def render("401.json-api", _assigns) do
     %{title: "Unauthorized", status: 401, detail: "You are not authorized to access this resource"}
@@ -19,9 +20,8 @@ defmodule OpenBudgetWeb.ErrorView do
     |> ErrorSerializer.format
   end
 
-  def render("422.json-api", _assigns) do
-    %{title: "Unprocessable entity", status: 422, detail: "There is an error with processing this resource"}
-    |> ErrorSerializer.format
+  def render("422.json-api", assigns) do
+    EctoErrorSerializer.format(assigns.changeset, [opts: [status: 422]])
   end
 
   def render("500.json-api", _assigns) do

--- a/lib/open_budget_web/views/error_view.ex
+++ b/lib/open_budget_web/views/error_view.ex
@@ -5,27 +5,27 @@ defmodule OpenBudgetWeb.ErrorView do
   alias JaSerializer.ErrorSerializer
 
   def render("401.json-api", _assigns) do
-    %{title: "Unauthorized", code: 401}
+    %{title: "Unauthorized", status: 401, detail: "You are not authorized to access this resource"}
     |> ErrorSerializer.format
   end
 
   def render("403.json-api", _assigns) do
-    %{title: "Forbidden", code: 403}
+    %{title: "Forbidden", status: 403, detail: "Accessing this resource is forbidden"}
     |> ErrorSerializer.format
   end
 
   def render("404.json-api", _assigns) do
-    %{title: "Resource not found", code: 404}
+    %{title: "Resource not found", status: 404, detail: "This resource cannot be found"}
     |> ErrorSerializer.format
   end
 
   def render("422.json-api", _assigns) do
-    %{title: "Unprocessable entity", code: 422}
+    %{title: "Unprocessable entity", status: 422, detail: "There is an error with processing this resource"}
     |> ErrorSerializer.format
   end
 
   def render("500.json-api", _assigns) do
-    %{title: "Internal server error", code: 500}
+    %{title: "Internal server error", status: 500, detail: "An unexpected error happened on the server"}
     |> ErrorSerializer.format
   end
 

--- a/test/open_budget/guardian/auth_error_handler_test.exs
+++ b/test/open_budget/guardian/auth_error_handler_test.exs
@@ -6,7 +6,15 @@ defmodule OpenBudget.Guardian.AuthErrorHandlerTest do
   describe("#auth_error") do
     test "sends 401 resp with {message: <type>} json as body", %{conn: conn} do
       conn = AuthErrorHandler.auth_error(conn, {:unauthorized, nil}, nil)
-      resp_body = Poison.encode!(%{jsonapi: %{version: "1.0"}, errors: [%{title: "Unauthorized", code: 401}]})
+      body = %{
+        jsonapi: %{version: "1.0"},
+        errors: [%{
+          title: "Unauthorized",
+          status: 401,
+          detail: "You are not authorized to access this resource"
+        }]
+      }
+      resp_body = Poison.encode!(body)
 
       assert conn.status == 401
       assert conn.resp_body == resp_body

--- a/test/open_budget_web/controllers/budget_controller_test.exs
+++ b/test/open_budget_web/controllers/budget_controller_test.exs
@@ -115,11 +115,24 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
     test "renders errors when data is invalid", %{conn: conn} do
       params = %{data: %{attributes: @invalid_attrs}}
       conn = post conn, budget_path(conn, :create), params
-      assert json_response(conn, 422)["errors"] == [%{
-        "title" => "Unprocessable entity",
-        "status" => 422,
-        "detail" => "There is an error with processing this resource"
-      }]
+      assert json_response(conn, 422)["errors"] == [
+        %{
+          "title" => "can't be blank",
+          "status" => 422,
+          "detail" => "Name can't be blank",
+          "source" => %{
+            "pointer" => "/data/attributes/name"
+          }
+        },
+        %{
+          "title" => "can't be blank",
+          "status" => 422,
+          "detail" => "Description can't be blank",
+          "source" => %{
+            "pointer" => "/data/attributes/description"
+          }
+        }
+      ]
     end
   end
 
@@ -146,11 +159,24 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
       Budgets.associate_user_to_budget(budget, user)
       params = %{data: %{attributes: @invalid_attrs}}
       conn = put conn, budget_path(conn, :update, budget), params
-      assert json_response(conn, 422)["errors"] == [%{
-        "title" => "Unprocessable entity",
-        "status" => 422,
-        "detail" => "There is an error with processing this resource"
-      }]
+      assert json_response(conn, 422)["errors"] == [
+        %{
+          "title" => "can't be blank",
+          "status" => 422,
+          "detail" => "Name can't be blank",
+          "source" => %{
+            "pointer" => "/data/attributes/name"
+          }
+        },
+        %{
+          "title" => "can't be blank",
+          "status" => 422,
+          "detail" => "Description can't be blank",
+          "source" => %{
+            "pointer" => "/data/attributes/description"
+          }
+        }
+      ]
     end
 
     test "renders error when budget is not associated with current user", %{conn: conn, budget: budget} do

--- a/test/open_budget_web/controllers/budget_controller_test.exs
+++ b/test/open_budget_web/controllers/budget_controller_test.exs
@@ -93,7 +93,8 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
       assert conn.status == 404
       assert json_response(conn, 404)["errors"] == [%{
         "title" => "Resource not found",
-        "code" => 404
+        "status" => 404,
+        "detail" => "This resource cannot be found"
       }]
     end
   end
@@ -116,7 +117,8 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
       conn = post conn, budget_path(conn, :create), params
       assert json_response(conn, 422)["errors"] == [%{
         "title" => "Unprocessable entity",
-        "code" => 422
+        "status" => 422,
+        "detail" => "There is an error with processing this resource"
       }]
     end
   end
@@ -146,7 +148,8 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
       conn = put conn, budget_path(conn, :update, budget), params
       assert json_response(conn, 422)["errors"] == [%{
         "title" => "Unprocessable entity",
-        "code" => 422
+        "status" => 422,
+        "detail" => "There is an error with processing this resource"
       }]
     end
 
@@ -155,7 +158,8 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
       conn = put conn, budget_path(conn, :update, budget), params
       assert json_response(conn, 404)["errors"] == [%{
         "title" => "Resource not found",
-        "code" => 404
+        "status" => 404,
+        "detail" => "This resource cannot be found"
       }]
     end
   end
@@ -174,7 +178,8 @@ defmodule OpenBudgetWeb.BudgetControllerTest do
       conn = delete conn, budget_path(conn, :delete, budget)
       assert json_response(conn, 404)["errors"] == [%{
         "title" => "Resource not found",
-        "code" => 404
+        "status" => 404,
+        "detail" => "This resource cannot be found"
       }]
     end
   end

--- a/test/open_budget_web/controllers/token_controller_test.exs
+++ b/test/open_budget_web/controllers/token_controller_test.exs
@@ -37,7 +37,7 @@ defmodule OpenBudgetWeb.TokenControllerTest do
       conn = post conn, token_path(conn, :create), params
       response = json_response(conn, 401)["errors"]
       response = hd(response)
-      assert response["code"] == 401
+      assert response["status"] == 401
       assert response["title"] == "Unauthorized"
     end
 
@@ -46,7 +46,7 @@ defmodule OpenBudgetWeb.TokenControllerTest do
       conn = post conn, token_path(conn, :create), params
       response = json_response(conn, 404)["errors"]
       response = hd(response)
-      assert response["code"] == 404
+      assert response["status"] == 404
       assert response["title"] == "Resource not found"
     end
   end

--- a/test/open_budget_web/views/error_view_test.exs
+++ b/test/open_budget_web/views/error_view_test.exs
@@ -41,12 +41,21 @@ defmodule OpenBudgetWeb.ErrorViewTest do
   end
 
   test "renders 422.json-api" do
-    assert render(OpenBudgetWeb.ErrorView, "422.json-api", []) ==
+    changeset = Ecto.Changeset.add_error(
+      %Ecto.Changeset{},
+      :monies,
+      "must be more than %{count}",
+      [count: 10]
+    )
+    assert render(OpenBudgetWeb.ErrorView, "422.json-api", changeset: changeset) ==
            %{
              "errors" => [%{
                status: 422,
-               title: "Unprocessable entity",
-               detail: "There is an error with processing this resource"
+               title: "must be more than 10",
+               detail: "Monies must be more than 10",
+               source: %{
+                 pointer: "/data/attributes/monies"
+               }
               }],
              "jsonapi" => %{"version" => "1.0"}
             }

--- a/test/open_budget_web/views/error_view_test.exs
+++ b/test/open_budget_web/views/error_view_test.exs
@@ -7,7 +7,11 @@ defmodule OpenBudgetWeb.ErrorViewTest do
   test "renders 401.json-api" do
     assert render(OpenBudgetWeb.ErrorView, "401.json-api", []) ==
            %{
-             "errors" => [%{code: 401, title: "Unauthorized"}],
+             "errors" => [%{
+               status: 401,
+               title: "Unauthorized",
+               detail: "You are not authorized to access this resource"
+              }],
              "jsonapi" => %{"version" => "1.0"}
             }
   end
@@ -15,7 +19,11 @@ defmodule OpenBudgetWeb.ErrorViewTest do
   test "renders 403.json-api" do
     assert render(OpenBudgetWeb.ErrorView, "403.json-api", []) ==
            %{
-             "errors" => [%{code: 403, title: "Forbidden"}],
+             "errors" => [%{
+               status: 403,
+               title: "Forbidden",
+               detail: "Accessing this resource is forbidden"
+              }],
              "jsonapi" => %{"version" => "1.0"}
             }
   end
@@ -23,7 +31,11 @@ defmodule OpenBudgetWeb.ErrorViewTest do
   test "renders 404.json-api" do
     assert render(OpenBudgetWeb.ErrorView, "404.json-api", []) ==
            %{
-             "errors" => [%{code: 404, title: "Resource not found"}],
+             "errors" => [%{
+               status: 404,
+               title: "Resource not found",
+               detail: "This resource cannot be found"
+              }],
              "jsonapi" => %{"version" => "1.0"}
             }
   end
@@ -31,7 +43,11 @@ defmodule OpenBudgetWeb.ErrorViewTest do
   test "renders 422.json-api" do
     assert render(OpenBudgetWeb.ErrorView, "422.json-api", []) ==
            %{
-             "errors" => [%{code: 422, title: "Unprocessable entity"}],
+             "errors" => [%{
+               status: 422,
+               title: "Unprocessable entity",
+               detail: "There is an error with processing this resource"
+              }],
              "jsonapi" => %{"version" => "1.0"}
             }
   end
@@ -39,7 +55,11 @@ defmodule OpenBudgetWeb.ErrorViewTest do
   test "render 500.json-api" do
     assert render(OpenBudgetWeb.ErrorView, "500.json-api", []) ==
            %{
-             "errors" => [%{code: 500, title: "Internal server error"}],
+             "errors" => [%{
+               status: 500,
+               title: "Internal server error",
+               detail: "An unexpected error happened on the server"
+              }],
              "jsonapi" => %{"version" => "1.0"}
             }
   end
@@ -47,7 +67,11 @@ defmodule OpenBudgetWeb.ErrorViewTest do
   test "render any other" do
     assert render(OpenBudgetWeb.ErrorView, "505.json", []) ==
            %{
-             "errors" => [%{code: 500, title: "Internal server error"}],
+             "errors" => [%{
+               status: 500,
+               title: "Internal server error",
+               detail: "An unexpected error happened on the server"
+              }],
              "jsonapi" => %{"version" => "1.0"}
             }
   end


### PR DESCRIPTION
This closes #27.

Currently, we return error responses this way:

```javascript
{
  "errors": [
    {
      "code": "422",
      "title":  "Unprocessable Entity"
    }
  ]
}
```

This isn't entirely correct and we should [return them according to the JSON API spec](http://jsonapi.org/examples/#error-objects-basics):

```javascript
{
  "errors": [
    {
      "status": "422",
      "source": { "pointer": "/data/attributes/first-name" },
      "title":  "Invalid Attribute",
      "detail": "First name must contain at least three characters."
    }
  ]
}
```