### PR TITLE
Road to 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Change all Budget endpoints to only show budgets associated with the current logged-in user.
 - Improve all error responses to adhere to JSON API.
 
+### Fixed
+
+- Fix clients being able to access `DELETE /token` without being authenticated.
+
 ## 0.1.0 - 2017-10-08
 
 ### Added

--- a/lib/open_budget_web/controllers/budget_controller.ex
+++ b/lib/open_budget_web/controllers/budget_controller.ex
@@ -67,10 +67,6 @@ defmodule OpenBudgetWeb.BudgetController do
       {:ok, budget} ->
         case Budgets.delete_budget(budget) do
           {:ok, _} -> send_resp(conn, :no_content, "")
-          {:error, _} ->
-            conn
-            |> put_status(422)
-            |> render(OpenBudgetWeb.ErrorView, "422.json-api")
         end
       {:error, _} ->
         conn

--- a/lib/open_budget_web/router.ex
+++ b/lib/open_budget_web/router.ex
@@ -25,12 +25,12 @@ defmodule OpenBudgetWeb.Router do
 
     resources "/budgets", BudgetController, except: [:new, :edit]
     resources "/users", UserController, except: [:new, :edit, :create]
+    delete "/token", TokenController, :delete
   end
 
   scope "/api/auth", OpenBudgetWeb do
     pipe_through :api
 
     resources "/token", TokenController, only: [:create]
-    delete "/token", TokenController, :delete
   end
 end

--- a/test/open_budget_web/controllers/token_controller_test.exs
+++ b/test/open_budget_web/controllers/token_controller_test.exs
@@ -2,6 +2,9 @@ defmodule OpenBudgetWeb.TokenControllerTest do
   use OpenBudgetWeb.ConnCase
 
   alias OpenBudget.Authentication, as: AuthContext
+  alias OpenBudget.Repo
+  alias OpenBudget.Authentication.User
+  alias OpenBudget.Guardian.Authentication, as: GuardianAuth
 
   @valid_attrs %{email: "test@example.com", password: "secretpassword"}
   @invalid_attrs %{email: "test@example.com", password: "wrongpassword"}
@@ -48,6 +51,20 @@ defmodule OpenBudgetWeb.TokenControllerTest do
       response = hd(response)
       assert response["status"] == 404
       assert response["title"] == "Resource not found"
+    end
+  end
+
+  describe "delete" do
+    test "renders nothing when a user signs out", %{conn: conn} do
+      user = Repo.get_by(User, email: "test@example.com")
+      conn = GuardianAuth.sign_in(conn, user)
+      conn = delete conn, token_path(conn, :delete)
+      assert conn.status == 204
+    end
+
+    test "renders error when sign out is accessed by unauthenticated user", %{conn: conn} do
+      conn = delete conn, token_path(conn, :delete)
+      assert conn.status == 401
     end
   end
 end


### PR DESCRIPTION
This PR covers the remaining lines of code that haven't been covered by tests yet.

One good thing I found in this endeavor was that `DELETE /token` had a bug where clients can access this endpoint without having to be authenticated.

Of course, this was simply an oversight, but this is still a bug nonetheless.