### PR TITLE
Allow users to switch active budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Code of Conduct.
 - Add Contributing Guidelines.
 - Add Budget resource (schema/endpoint).
+- Add active budgets and allow users to switch between budgets.
 
 ### Changed
 

--- a/lib/open_budget/authentication/user.ex
+++ b/lib/open_budget/authentication/user.ex
@@ -11,6 +11,7 @@ defmodule OpenBudget.Authentication.User do
   import Ecto.Changeset
   alias OpenBudget.Authentication.User
   alias OpenBudget.Budgets.BudgetUser
+  alias OpenBudget.Budgets.Budget
   alias Comeonin.Argon2
 
   schema "users" do
@@ -19,6 +20,7 @@ defmodule OpenBudget.Authentication.User do
     field :password_hash, :string
     many_to_many :budgets, OpenBudget.Budgets.Budget,
                 join_through: BudgetUser, unique: true
+    belongs_to :active_budget, Budget
 
     timestamps()
   end
@@ -37,6 +39,10 @@ defmodule OpenBudget.Authentication.User do
     |> cast(attrs, ~w(password), [])
     |> validate_length(:password, min: 6, max: 30)
     |> put_password_hash()
+  end
+
+  def active_budget_changeset(%User{} = user, attrs) do
+    user |> cast(attrs, [:active_budget_id])
   end
 
   defp put_password_hash(changeset) do

--- a/lib/open_budget_web/controllers/budget_controller.ex
+++ b/lib/open_budget_web/controllers/budget_controller.ex
@@ -74,4 +74,17 @@ defmodule OpenBudgetWeb.BudgetController do
         |> render(OpenBudgetWeb.ErrorView, "404.json-api")
     end
   end
+
+  def switch(conn, %{"budget_id" => id}) do
+    current_user = Plug.current_resource(conn)
+    case Budgets.get_budget(id, current_user) do
+      {:ok, budget} ->
+        {:ok, budget, _} = Budgets.switch_active_budget(budget, current_user)
+        render(conn, "show.json-api", data: budget)
+      {:error, _} ->
+        conn
+        |> put_status(404)
+        |> render(OpenBudgetWeb.ErrorView, "404.json-api")
+    end
+  end
 end

--- a/lib/open_budget_web/router.ex
+++ b/lib/open_budget_web/router.ex
@@ -23,7 +23,9 @@ defmodule OpenBudgetWeb.Router do
   scope "/api", OpenBudgetWeb do
     pipe_through :api_auth
 
-    resources "/budgets", BudgetController, except: [:new, :edit]
+    resources "/budgets", BudgetController, except: [:new, :edit] do
+      post "/switch", BudgetController, :switch, as: :switch
+    end
     resources "/users", UserController, except: [:new, :edit, :create]
     delete "/token", TokenController, :delete
   end

--- a/priv/repo/migrations/20171023235916_add_active_budget_to_user.exs
+++ b/priv/repo/migrations/20171023235916_add_active_budget_to_user.exs
@@ -1,0 +1,9 @@
+defmodule OpenBudget.Repo.Migrations.AddActiveBudgetToUser do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :active_budget_id, references(:budgets)
+    end
+  end
+end

--- a/test/open_budget/budgets/budgets_test.exs
+++ b/test/open_budget/budgets/budgets_test.exs
@@ -193,5 +193,33 @@ defmodule OpenBudget.BudgetsTest do
       assert Kernel.length(result) == 2
       assert user_result.email == "existing@example.com"
     end
+
+    test "switch_active_budget/2 switches the active budget when the budget is associated with the given user" do
+      budget = budget_fixture()
+      other_budget = budget_fixture(%{name: "Other Budget"})
+      user = user_fixture()
+      Budgets.associate_user_to_budget(budget, user)
+      Budgets.associate_user_to_budget(other_budget, user)
+
+      {:ok, budget, user} = Budgets.switch_active_budget(budget, user)
+      assert user.active_budget_id == budget.id
+
+      {:ok, other_budget, user} = Budgets.switch_active_budget(other_budget, user)
+      assert user.active_budget_id == other_budget.id
+    end
+
+    test "switch_active_budget/2 returns an error when the budget is not associated with the given user" do
+      budget = budget_fixture()
+      other_budget = budget_fixture(%{name: "Other Budget"})
+      user = user_fixture()
+      Budgets.associate_user_to_budget(budget, user)
+
+      {:ok, budget, user} = Budgets.switch_active_budget(budget, user)
+      assert user.active_budget_id == budget.id
+
+      assert Budgets.switch_active_budget(other_budget, user) == {:error, "Budget not found"}
+      assert user.active_budget_id != other_budget.id
+      assert user.active_budget_id == budget.id
+    end
   end
 end


### PR DESCRIPTION
This closes #9.

This adds a new context method called `Budget.switch_active_budget/2` and a new endpoint `Budget#switch`