### PR TITLE
Add Account and Budget association

### DIFF
--- a/lib/open_budget/budgets/account.ex
+++ b/lib/open_budget/budgets/account.ex
@@ -14,11 +14,13 @@ defmodule OpenBudget.Budgets.Account do
   use Ecto.Schema
   import Ecto.Changeset
   alias OpenBudget.Budgets.Account
+  alias OpenBudget.Budgets.Budget
 
   schema "accounts" do
     field :description, :string
     field :name, :string
     field :category, :string
+    belongs_to :budget, Budget
 
     timestamps()
   end

--- a/lib/open_budget/budgets/account.ex
+++ b/lib/open_budget/budgets/account.ex
@@ -31,4 +31,11 @@ defmodule OpenBudget.Budgets.Account do
     |> cast(attrs, [:name, :description, :category])
     |> validate_required([:name, :description, :category])
   end
+
+  @doc false
+  def budget_association_changeset(%Account{} = account, attrs) do
+    account
+    |> cast(attrs, [:budget_id])
+    |> validate_required([:budget_id])
+  end
 end

--- a/lib/open_budget/budgets/budget.ex
+++ b/lib/open_budget/budgets/budget.ex
@@ -4,6 +4,7 @@ defmodule OpenBudget.Budgets.Budget do
   """
   use Ecto.Schema
   import Ecto.Changeset
+  alias OpenBudget.Budgets.Account
   alias OpenBudget.Budgets.Budget
   alias OpenBudget.Budgets.BudgetUser
   alias OpenBudget.Authentication.User
@@ -15,6 +16,7 @@ defmodule OpenBudget.Budgets.Budget do
                        join_through: BudgetUser,
                        unique: true,
                        on_delete: :delete_all
+    has_many :accounts, Account, on_delete: :delete_all
 
     timestamps()
   end

--- a/lib/open_budget/budgets/budgets.ex
+++ b/lib/open_budget/budgets/budgets.ex
@@ -7,6 +7,7 @@ defmodule OpenBudget.Budgets do
   alias OpenBudget.Repo
 
   alias OpenBudget.Budgets.Account
+  alias OpenBudget.Budgets.Budget
   alias OpenBudget.Budgets.BudgetUser
   alias OpenBudget.Authentication.User
 
@@ -104,7 +105,29 @@ defmodule OpenBudget.Budgets do
     Account.changeset(account, %{})
   end
 
-  alias OpenBudget.Budgets.Budget
+  @doc """
+  Adds an association between a Budget and an Account.
+
+  ## Examples
+      iex> associate_account_to_budget(account, budget)
+      {:ok, %Budget{}, %Account{}}
+
+      iex> associate_account_to_budget(account, %Budget{})
+      {:error, %Ecto.Changeset{}}
+  """
+  def associate_account_to_budget(%Account{} = account, %Budget{} = budget) do
+    changeset =
+      account
+      |> Account.budget_association_changeset(%{budget_id: budget.id})
+      |> Repo.update()
+
+    case changeset do
+      {:ok, account} ->
+        account = Repo.preload(account, :budget)
+        {:ok, account}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
 
   @doc """
   Returns the list of budgets.

--- a/lib/open_budget/budgets/budgets.ex
+++ b/lib/open_budget/budgets/budgets.ex
@@ -25,6 +25,21 @@ defmodule OpenBudget.Budgets do
   end
 
   @doc """
+  Returns a list of accounts associated with the given budget.
+
+  ## Examples
+
+      iex> list_accounts(budget)
+      [%Account{}, ...]
+  """
+  def list_accounts(budget) do
+    Repo.all(from a in Account,
+            preload: [:budget],
+            left_join: b in Budget, on: b.id == a.budget_id,
+            where: b.id == ^budget.id)
+  end
+
+  @doc """
   Gets a single account.
 
   Raises `Ecto.NoResultsError` if the Account does not exist.

--- a/lib/open_budget/budgets/budgets.ex
+++ b/lib/open_budget/budgets/budgets.ex
@@ -42,18 +42,21 @@ defmodule OpenBudget.Budgets do
   @doc """
   Gets a single account.
 
-  Raises `Ecto.NoResultsError` if the Account does not exist.
-
   ## Examples
 
-      iex> get_account!(123)
+      iex> get_account(123)
       %Account{}
 
-      iex> get_account!(456)
+      iex> get_account(456)
       ** (Ecto.NoResultsError)
 
   """
-  def get_account!(id), do: Repo.get!(Account, id)
+  def get_account(id) do
+    budget = Repo.get!(Account, id)
+    {:ok, budget}
+  rescue
+    Ecto.NoResultsError -> {:error, "Account not found"}
+  end
 
   @doc """
   Creates a account.

--- a/lib/open_budget/budgets/budgets.ex
+++ b/lib/open_budget/budgets/budgets.ex
@@ -74,6 +74,34 @@ defmodule OpenBudget.Budgets do
   end
 
   @doc """
+  Creates a account and associated it with the given budget.
+
+  ## Examples
+
+      iex> create_account(%{field: value}, budget)
+      {:ok, %Account{}}
+
+      iex> create_account(%{field: bad_value}, budget)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_account(attrs, budget) do
+    changeset =
+      %Account{}
+      |> Account.changeset(attrs)
+      |> Repo.insert()
+
+    case changeset do
+      {:ok, account} ->
+        {:ok, account} = associate_account_to_budget(account, budget)
+        account = Repo.preload(account, :budget)
+        {:ok, account}
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  @doc """
   Updates a account.
 
   ## Examples

--- a/lib/open_budget/budgets/budgets.ex
+++ b/lib/open_budget/budgets/budgets.ex
@@ -59,6 +59,28 @@ defmodule OpenBudget.Budgets do
   end
 
   @doc """
+  Gets a single account associated with the given budget.
+
+  ## Examples
+
+      iex> get_account(123, budget)
+      {:ok, %Account{}}
+
+      iex> get_account(456, budget)
+      {:error, "Account not found"}
+
+  """
+  def get_account(id, budget) do
+    account = Repo.one!(from a in Account,
+                        preload: [:budget],
+                        left_join: b in Budget, on: b.id == a.budget_id,
+                        where: b.id == ^budget.id and a.id == ^id)
+    {:ok, account}
+  rescue
+    Ecto.NoResultsError -> {:error, "Account not found"}
+  end
+
+  @doc """
   Creates a account.
 
   ## Examples

--- a/lib/open_budget/budgets/budgets.ex
+++ b/lib/open_budget/budgets/budgets.ex
@@ -153,7 +153,7 @@ defmodule OpenBudget.Budgets do
 
   ## Examples
       iex> associate_account_to_budget(account, budget)
-      {:ok, %Budget{}, %Account{}}
+      {:ok, %Account{}}
 
       iex> associate_account_to_budget(account, %Budget{})
       {:error, %Ecto.Changeset{}}

--- a/lib/open_budget_web/controllers/account_controller.ex
+++ b/lib/open_budget_web/controllers/account_controller.ex
@@ -4,11 +4,15 @@ defmodule OpenBudgetWeb.AccountController do
   alias OpenBudget.Budgets
   alias OpenBudget.Budgets.Account
   alias JaSerializer.Params
+  alias Guardian.Plug
+  alias OpenBudget.Repo
 
   action_fallback OpenBudgetWeb.FallbackController
 
   def index(conn, _params) do
-    accounts = Budgets.list_accounts()
+    current_user = Plug.current_resource(conn)
+    current_user = Repo.preload(current_user, [:active_budget])
+    accounts = Budgets.list_accounts(current_user.active_budget)
     render(conn, "index.json-api", data: accounts)
   end
 

--- a/lib/open_budget_web/controllers/account_controller.ex
+++ b/lib/open_budget_web/controllers/account_controller.ex
@@ -35,13 +35,13 @@ defmodule OpenBudgetWeb.AccountController do
   end
 
   def show(conn, %{"id" => id}) do
-    account = Budgets.get_account!(id)
+    {:ok, account} = Budgets.get_account(id)
     render(conn, "show.json-api", data: account)
   end
 
   def update(conn, %{"id" => id, "data" => data}) do
     attrs = Params.to_attributes(data)
-    account = Budgets.get_account!(id)
+    {:ok, account} = Budgets.get_account(id)
 
     with {:ok, %Account{} = account} <-
       Budgets.update_account(account, attrs) do
@@ -50,7 +50,7 @@ defmodule OpenBudgetWeb.AccountController do
   end
 
   def delete(conn, %{"id" => id}) do
-    account = Budgets.get_account!(id)
+    {:ok, account} = Budgets.get_account(id)
     with {:ok, %Account{}} <- Budgets.delete_account(account) do
       send_resp(conn, :no_content, "")
     end

--- a/lib/open_budget_web/views/account_view.ex
+++ b/lib/open_budget_web/views/account_view.ex
@@ -2,5 +2,6 @@ defmodule OpenBudgetWeb.AccountView do
   use OpenBudgetWeb, :view
   use JaSerializer.PhoenixView
 
+  location "/accounts/:id"
   attributes [:name, :description, :category]
 end

--- a/lib/open_budget_web/views/account_view.ex
+++ b/lib/open_budget_web/views/account_view.ex
@@ -4,4 +4,9 @@ defmodule OpenBudgetWeb.AccountView do
 
   location "/accounts/:id"
   attributes [:name, :description, :category]
+
+  has_one :budget,
+    serializer: OpenBudgetWeb.BudgetView,
+    include: false,
+    identifiers: :when_included
 end

--- a/priv/repo/migrations/20171025151647_add_budget_id_to_accounts.exs
+++ b/priv/repo/migrations/20171025151647_add_budget_id_to_accounts.exs
@@ -1,0 +1,9 @@
+defmodule OpenBudget.Repo.Migrations.AddBudgetIdToAccounts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:accounts) do
+      add :budget_id, references(:budgets, on_delete: :delete_all)
+    end
+  end
+end

--- a/test/open_budget/budgets/budgets_test.exs
+++ b/test/open_budget/budgets/budgets_test.exs
@@ -1,25 +1,47 @@
 defmodule OpenBudget.BudgetsTest do
   use OpenBudget.DataCase
 
-  alias OpenBudget.Budgets
   alias OpenBudget.Authentication
+  alias OpenBudget.Budgets
+  alias OpenBudget.Budgets.Account
+  alias OpenBudget.Budgets.Budget
+
+  @create_account_attrs %{name: "Sample Account", description: "This is a sample account", category: "Cash"}
+  @update_account_attrs %{name: "Updated Sample Account", description: "This is an updated sample account", category: "Cash"}
+  @invalid_account_attrs %{name: nil, description: nil, category: nil}
+
+  @create_budget_attrs %{name: "Sample Budget", description: "This is a sample budget"}
+  @update_budget_attrs %{name: "Updated Sample Budget", description: "This is an updated sample budget"}
+  @invalid_budget_attrs %{name: nil, description: nil}
+
+  def account_fixture(attrs \\ %{}) do
+    {:ok, account} =
+      attrs
+      |> Enum.into(@create_account_attrs)
+      |> Budgets.create_account()
+
+    account
+  end
+
+  def budget_fixture(attrs \\ %{}) do
+    {:ok, budget} =
+      attrs
+      |> Enum.into(@create_budget_attrs)
+      |> Budgets.create_budget()
+
+    budget
+  end
+
+  def user_fixture(attrs \\ %{}) do
+    {:ok, user} =
+      attrs
+      |> Enum.into(%{email: "test@example.com", password: "password"})
+      |> Authentication.create_user()
+
+    user
+  end
 
   describe "accounts" do
-    alias OpenBudget.Budgets.Account
-
-    @valid_attrs %{description: "some description", name: "some name", category: "some type"}
-    @update_attrs %{description: "some updated description", name: "some updated name", category: "some updated type"}
-    @invalid_attrs %{description: nil, name: nil, type: nil}
-
-    def account_fixture(attrs \\ %{}) do
-      {:ok, account} =
-        attrs
-        |> Enum.into(@valid_attrs)
-        |> Budgets.create_account()
-
-      account
-    end
-
     test "list_accounts/0 returns all accounts" do
       account = account_fixture()
       assert Budgets.list_accounts() == [account]
@@ -31,28 +53,28 @@ defmodule OpenBudget.BudgetsTest do
     end
 
     test "create_account/1 with valid data creates a account" do
-      assert {:ok, %Account{} = account} = Budgets.create_account(@valid_attrs)
-      assert account.description == "some description"
-      assert account.name == "some name"
-      assert account.category == "some type"
+      assert {:ok, %Account{} = account} = Budgets.create_account(@create_account_attrs)
+      assert account.name == "Sample Account"
+      assert account.description == "This is a sample account"
+      assert account.category == "Cash"
     end
 
     test "create_account/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Budgets.create_account(@invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Budgets.create_account(@invalid_account_attrs)
     end
 
     test "update_account/2 with valid data updates the account" do
       account = account_fixture()
-      assert {:ok, account} = Budgets.update_account(account, @update_attrs)
+      assert {:ok, account} = Budgets.update_account(account, @update_account_attrs)
       assert %Account{} = account
-      assert account.description == "some updated description"
-      assert account.name == "some updated name"
-      assert account.category == "some updated type"
+      assert account.name == "Updated Sample Account"
+      assert account.description == "This is an updated sample account"
+      assert account.category == "Cash"
     end
 
     test "update_account/2 with invalid data returns error changeset" do
       account = account_fixture()
-      assert {:error, %Ecto.Changeset{}} = Budgets.update_account(account, @invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Budgets.update_account(account, @invalid_account_attrs)
       assert account == Budgets.get_account!(account.id)
     end
 
@@ -69,30 +91,6 @@ defmodule OpenBudget.BudgetsTest do
   end
 
   describe "budgets" do
-    alias OpenBudget.Budgets.Budget
-
-    @valid_attrs %{name: "Sample Budget", description: "This is a sample budget"}
-    @update_attrs %{name: "Updated Sample Budget", description: "This is an updated sample budget"}
-    @invalid_attrs %{name: nil, description: nil}
-
-    def budget_fixture(attrs \\ %{}) do
-      {:ok, budget} =
-        attrs
-        |> Enum.into(@valid_attrs)
-        |> Budgets.create_budget()
-
-      budget
-    end
-
-    def user_fixture(attrs \\ %{}) do
-      {:ok, user} =
-        attrs
-        |> Enum.into(%{email: "test@example.com", password: "password"})
-        |> Authentication.create_user()
-
-      user
-    end
-
     test "list_budgets/0 returns all budgets" do
       budget = budget_fixture()
       assert Budgets.list_budgets() == [budget]
@@ -128,30 +126,30 @@ defmodule OpenBudget.BudgetsTest do
     end
 
     test "create_budget/1 with valid data creates a budget" do
-      assert {:ok, %Budget{} = budget} = Budgets.create_budget(@valid_attrs)
+      assert {:ok, %Budget{} = budget} = Budgets.create_budget(@create_budget_attrs)
       assert budget.name == "Sample Budget"
       assert budget.description == "This is a sample budget"
     end
 
     test "create_budget/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Budgets.create_budget(@invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Budgets.create_budget(@invalid_budget_attrs)
     end
 
     test "create_budget/2 with valid data creates a budget" do
       user = user_fixture()
-      assert {:ok, %Budget{} = budget} = Budgets.create_budget(@valid_attrs, user)
+      assert {:ok, %Budget{} = budget} = Budgets.create_budget(@create_budget_attrs, user)
       assert budget.name == "Sample Budget"
       assert budget.description == "This is a sample budget"
     end
 
     test "create_budget/2 with invalid data returns error changeset" do
       user = user_fixture()
-      assert {:error, %Ecto.Changeset{}} = Budgets.create_budget(@invalid_attrs, user)
+      assert {:error, %Ecto.Changeset{}} = Budgets.create_budget(@invalid_budget_attrs, user)
     end
 
     test "update_budget/2 with valid data updates the budget" do
       budget = budget_fixture()
-      assert {:ok, budget} = Budgets.update_budget(budget, @update_attrs)
+      assert {:ok, budget} = Budgets.update_budget(budget, @update_budget_attrs)
       assert %Budget{} = budget
       assert budget.name == "Updated Sample Budget"
       assert budget.description == "This is an updated sample budget"
@@ -159,7 +157,7 @@ defmodule OpenBudget.BudgetsTest do
 
     test "update_budget/2 with invalid data returns error changeset" do
       budget = budget_fixture()
-      assert {:error, %Ecto.Changeset{}} = Budgets.update_budget(budget, @invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Budgets.update_budget(budget, @invalid_budget_attrs)
       assert {:ok, budget} == Budgets.get_budget(budget.id)
     end
 

--- a/test/open_budget/budgets/budgets_test.exs
+++ b/test/open_budget/budgets/budgets_test.exs
@@ -47,6 +47,14 @@ defmodule OpenBudget.BudgetsTest do
       assert Budgets.list_accounts() == [account]
     end
 
+    test "list_accounts/1 returns all accounts associated with the given budget" do
+      account = account_fixture()
+      account_fixture(%{name: "Other account"})
+      budget = budget_fixture()
+      {:ok, account} = Budgets.associate_account_to_budget(account, budget)
+      assert Budgets.list_accounts(budget) == [account]
+    end
+
     test "get_account!/1 returns the account with given id" do
       account = account_fixture()
       assert Budgets.get_account!(account.id) == account

--- a/test/open_budget/budgets/budgets_test.exs
+++ b/test/open_budget/budgets/budgets_test.exs
@@ -88,6 +88,22 @@ defmodule OpenBudget.BudgetsTest do
       account = account_fixture()
       assert %Ecto.Changeset{} = Budgets.change_account(account)
     end
+
+    test "associate_account_to_budget/2 associates an account with a budget" do
+      account = account_fixture()
+      budget = budget_fixture()
+      {:ok, account} = Budgets.associate_account_to_budget(account, budget)
+
+      assert account.budget == budget
+    end
+
+    test "associate_account_to_budget/2 returns an error when an account is associated with blank budget" do
+      account = account_fixture()
+      {result, changeset} = Budgets.associate_account_to_budget(account, %Budget{})
+
+      assert result == :error
+      assert changeset.errors == [budget_id: {"can't be blank", [validation: :required]}]
+    end
   end
 
   describe "budgets" do

--- a/test/open_budget/budgets/budgets_test.exs
+++ b/test/open_budget/budgets/budgets_test.exs
@@ -71,6 +71,21 @@ defmodule OpenBudget.BudgetsTest do
       assert {:error, %Ecto.Changeset{}} = Budgets.create_account(@invalid_account_attrs)
     end
 
+    test "create_account/2 with valid data creates a account and associates with the budget" do
+      budget = budget_fixture()
+
+      assert {:ok, %Account{} = account} = Budgets.create_account(@create_account_attrs, budget)
+      assert account.name == "Sample Account"
+      assert account.description == "This is a sample account"
+      assert account.category == "Cash"
+      assert account.budget == budget
+    end
+
+    test "create_account/2 with invalid data returns error changeset" do
+      budget = budget_fixture()
+      assert {:error, %Ecto.Changeset{}} = Budgets.create_account(@invalid_account_attrs, budget)
+    end
+
     test "update_account/2 with valid data updates the account" do
       account = account_fixture()
       assert {:ok, account} = Budgets.update_account(account, @update_account_attrs)

--- a/test/open_budget/budgets/budgets_test.exs
+++ b/test/open_budget/budgets/budgets_test.exs
@@ -55,9 +55,13 @@ defmodule OpenBudget.BudgetsTest do
       assert Budgets.list_accounts(budget) == [account]
     end
 
-    test "get_account!/1 returns the account with given id" do
+    test "get_account/1 returns the account with given id" do
       account = account_fixture()
-      assert Budgets.get_account!(account.id) == account
+      assert Budgets.get_account(account.id) == {:ok, account}
+    end
+
+    test "get_account/1 with invalid id returns error" do
+      assert Budgets.get_account(1) == {:error, "Account not found"}
     end
 
     test "create_account/1 with valid data creates a account" do
@@ -98,13 +102,12 @@ defmodule OpenBudget.BudgetsTest do
     test "update_account/2 with invalid data returns error changeset" do
       account = account_fixture()
       assert {:error, %Ecto.Changeset{}} = Budgets.update_account(account, @invalid_account_attrs)
-      assert account == Budgets.get_account!(account.id)
+      assert {:ok, account} == Budgets.get_account(account.id)
     end
 
     test "delete_account/1 deletes the account" do
       account = account_fixture()
       assert {:ok, %Account{}} = Budgets.delete_account(account)
-      assert_raise Ecto.NoResultsError, fn -> Budgets.get_account!(account.id) end
     end
 
     test "change_account/1 returns a account changeset" do

--- a/test/open_budget/budgets/budgets_test.exs
+++ b/test/open_budget/budgets/budgets_test.exs
@@ -64,6 +64,25 @@ defmodule OpenBudget.BudgetsTest do
       assert Budgets.get_account(1) == {:error, "Account not found"}
     end
 
+    test "get_account!/2 returns the budget-associated account with given id" do
+      account = account_fixture()
+      budget = budget_fixture()
+      Budgets.associate_account_to_budget(account, budget)
+      {status, result} = Budgets.get_account(account.id, budget)
+
+      assert status == :ok
+      assert result.id == account.id
+    end
+
+    test "get_account!/2 with no budget-account association returns error" do
+      account = account_fixture()
+      budget = budget_fixture()
+      {status, message} = Budgets.get_account(account.id, budget)
+
+      assert status == :error
+      assert message == "Account not found"
+    end
+
     test "create_account/1 with valid data creates a account" do
       assert {:ok, %Account{} = account} = Budgets.create_account(@create_account_attrs)
       assert account.name == "Sample Account"

--- a/test/open_budget_web/controllers/account_controller_test.exs
+++ b/test/open_budget_web/controllers/account_controller_test.exs
@@ -223,6 +223,22 @@ defmodule OpenBudgetWeb.AccountControllerTest do
       conn = put conn, account_path(conn, :update, account), params
       assert json_response(conn, 422)["errors"] != %{}
     end
+
+    test "renders error when account id is not associated with a budget", %{conn: conn, account: account} do
+      user = Repo.get_by(User, email: "test@example.com")
+      budget = budget_fixture()
+      Budgets.associate_user_to_budget(budget, user)
+      Budgets.switch_active_budget(budget, user)
+
+      params = Poison.encode!(%{data: %{attributes: @update_account_attrs}})
+      conn = put conn, account_path(conn, :update, account), params
+
+      assert json_response(conn, 404)["errors"] == [%{
+        "title" => "Resource not found",
+        "status" => 404,
+        "detail" => "This resource cannot be found"
+      }]
+    end
   end
 
   describe "delete account" do

--- a/test/open_budget_web/controllers/account_controller_test.exs
+++ b/test/open_budget_web/controllers/account_controller_test.exs
@@ -72,6 +72,9 @@ defmodule OpenBudgetWeb.AccountControllerTest do
             "name" => "Sample Account",
             "description" => "This is an account",
             "category" => "Cash"
+          },
+          "links" => %{
+            "self" => "/accounts/#{account.id}"
           }
         },
         %{
@@ -81,6 +84,9 @@ defmodule OpenBudgetWeb.AccountControllerTest do
             "name" => "Other Account",
             "description" => "This is an account",
             "category" => "Cash"
+          },
+          "links" => %{
+            "self" => "/accounts/#{other_account.id}"
           }
         }
       ]
@@ -99,6 +105,9 @@ defmodule OpenBudgetWeb.AccountControllerTest do
           "name" => "Sample Account",
           "description" => "This is an account",
           "category" => "Cash"
+        },
+        "links" => %{
+          "self" => "/accounts/#{account.id}"
         }
       }
     end
@@ -137,6 +146,9 @@ defmodule OpenBudgetWeb.AccountControllerTest do
           "name" => "Updated Sample Account",
           "description" => "This is an updated account",
           "category" => "Cash"
+        },
+        "links" => %{
+          "self" => "/accounts/#{id}"
         }
       }
     end

--- a/test/open_budget_web/controllers/account_controller_test.exs
+++ b/test/open_budget_web/controllers/account_controller_test.exs
@@ -124,6 +124,11 @@ defmodule OpenBudgetWeb.AccountControllerTest do
 
   describe "create account" do
     test "renders account when data is valid", %{conn: conn} do
+      user = Repo.get_by(User, %{email: "test@example.com"})
+      budget = budget_fixture()
+      Budgets.associate_user_to_budget(budget, user)
+      Budgets.switch_active_budget(budget, user)
+
       params = Poison.encode!(%{data: %{attributes: @create_account_attrs}})
       conn = post conn, account_path(conn, :create), params
       response = json_response(conn, 201)["data"]
@@ -132,6 +137,15 @@ defmodule OpenBudgetWeb.AccountControllerTest do
         "name" => "Sample Account",
         "description" => "This is an account",
         "category" => "Cash"
+      }
+
+      assert response["relationships"] == %{
+        "budget" => %{
+          "data" => %{
+            "id" => "#{budget.id}",
+            "type" => "budget"
+          }
+        }
       }
     end
 

--- a/test/open_budget_web/controllers/account_controller_test.exs
+++ b/test/open_budget_web/controllers/account_controller_test.exs
@@ -75,6 +75,9 @@ defmodule OpenBudgetWeb.AccountControllerTest do
           },
           "links" => %{
             "self" => "/accounts/#{account.id}"
+          },
+          "relationships" => %{
+            "budget" => %{}
           }
         },
         %{
@@ -87,6 +90,9 @@ defmodule OpenBudgetWeb.AccountControllerTest do
           },
           "links" => %{
             "self" => "/accounts/#{other_account.id}"
+          },
+          "relationships" => %{
+            "budget" => %{}
           }
         }
       ]
@@ -108,6 +114,9 @@ defmodule OpenBudgetWeb.AccountControllerTest do
         },
         "links" => %{
           "self" => "/accounts/#{account.id}"
+        },
+        "relationships" => %{
+          "budget" => %{}
         }
       }
     end
@@ -149,6 +158,9 @@ defmodule OpenBudgetWeb.AccountControllerTest do
         },
         "links" => %{
           "self" => "/accounts/#{id}"
+        },
+        "relationships" => %{
+          "budget" => %{}
         }
       }
     end


### PR DESCRIPTION
This closes #8 and #12.

This changes the whole Accounts resource to retrieve and manipulate accounts based on the current active budget.