### PR TITLE
Create default budget and authenticate newly-registered users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add Contributing Guidelines.
 - Add Budget resource (schema/endpoint).
 - Add active budgets and allow users to switch between budgets.
+- Automatically create a default active budget and authenticate for users created through `POST /users`.
 
 ### Changed
 

--- a/lib/open_budget_web/views/user_view.ex
+++ b/lib/open_budget_web/views/user_view.ex
@@ -4,4 +4,9 @@ defmodule OpenBudgetWeb.UserView do
 
   location "/users/:id"
   attributes [:email]
+
+  has_one :active_budget,
+    serializer: OpenBudgetWeb.BudgetView,
+    include: false,
+    identifiers: :when_included
 end

--- a/test/open_budget_web/controllers/user_controller_test.exs
+++ b/test/open_budget_web/controllers/user_controller_test.exs
@@ -51,6 +51,9 @@ defmodule OpenBudgetWeb.UserControllerTest do
         },
         "links" => %{
           "self" => "/users/#{user.id}"
+        },
+        "relationships" => %{
+          "active-budget" => %{}
         }
       }
     end
@@ -61,10 +64,13 @@ defmodule OpenBudgetWeb.UserControllerTest do
       params = Poison.encode!(%{data: %{attributes: @create_attrs}})
       conn = post conn, user_path(conn, :create), params
       response = json_response(conn, 201)["data"]
+      {auth_header, _} = hd(Enum.reverse(conn.resp_headers))
 
+      assert auth_header == "authorization"
       assert response["attributes"] == %{
         "email" => "test@example.com"
       }
+      assert response["relationships"]["active-budget"]["data"]["id"] != ""
     end
 
     test "renders errors when data is invalid", %{conn: conn} do


### PR DESCRIPTION
This closes #36.

This changes `POST /users` to create a default budget and set it as the active budget for newly-registered users.

It also authenticates the user inside the application at the same time.