### PR TITLE
Fix Token deletion route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- Fix Token deletion URL to be /auth/token instead of /token
+
 ## [0.2.0](https://github.com/obudget/core/releases/tag/v0.2.0) - 2017-10-28 - [Diff](https://github.com/obudget/core/compare/v0.1.0...v0.2.0)
 
 ### Added

--- a/lib/open_budget_web/router.ex
+++ b/lib/open_budget_web/router.ex
@@ -27,7 +27,7 @@ defmodule OpenBudgetWeb.Router do
       post "/switch", BudgetController, :switch, as: :switch
     end
     resources "/users", UserController, except: [:new, :edit, :create]
-    delete "/token", TokenController, :delete
+    delete "/auth/token", TokenController, :delete
   end
 
   scope "/api/auth", OpenBudgetWeb do


### PR DESCRIPTION
I didn't notice this until now, but the delete token url before was `DELETE /token` instead of `DELETE /auth/token`.

This PR fixes this oversight.