### PR TITLE
Halt any controller render after 401 return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fix Token deletion URL to be /auth/token instead of /token
+- Fix Token deletion URL to be /auth/token instead of /token.
+- Fix repeated controller render after Guardian returns 401.
 
 ## [0.2.0](https://github.com/obudget/core/releases/tag/v0.2.0) - 2017-10-28 - [Diff](https://github.com/obudget/core/compare/v0.1.0...v0.2.0)
 

--- a/lib/open_budget/guardian/auth_error_handler.ex
+++ b/lib/open_budget/guardian/auth_error_handler.ex
@@ -8,5 +8,6 @@ defmodule OpenBudget.Guardian.AuthErrorHandler do
     conn
     |> put_status(401)
     |> render(OpenBudgetWeb.ErrorView, "401.json-api")
+    |> halt
   end
 end


### PR DESCRIPTION
There was a bug where an exception is raised when Guardian already returns a 401 error and it continues to do another render. It's similar to what happens with Rails when you're doing too much rendering.