### PR TITLE
Support different cors origins depending on app environment

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -15,7 +15,8 @@ config :open_budget, OpenBudgetWeb.Endpoint,
   secret_key_base: "aN2o/h57OsXeuJTFr6A2XwENBMTJazo2mtGAi84mMwvJc/or8VO4Ig60mW+xlgQb",
   render_errors: [view: OpenBudgetWeb.ErrorView, accepts: ~w(json json-api)],
   pubsub: [name: OpenBudget.PubSub,
-           adapter: Phoenix.PubSub.PG2]
+           adapter: Phoenix.PubSub.PG2],
+  frontend_host: "http://localhost:3000"
 
 # Configures Elixir's Logger
 config :logger, :console,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,7 +18,8 @@ config :open_budget, OpenBudgetWeb.Endpoint,
   load_from_system_env: true,
   server: true,
   version: Mix.Project.config[:version],
-  secret_key_base: "${SECRET_KEY_BASE}"
+  secret_key_base: "${SECRET_KEY_BASE}",
+  frontend_host: "https://app.openbudget.xyz"
 
 # Do not print debug messages in production
 config :logger, level: :info

--- a/lib/open_budget_web/endpoint.ex
+++ b/lib/open_budget_web/endpoint.ex
@@ -38,7 +38,7 @@ defmodule OpenBudgetWeb.Endpoint do
 
   plug Corsica,
     max_age: 86_000,
-    origins: "http://localhost:3000",
+    origins: Application.get_env(:open_budget, OpenBudgetWeb.Endpoint)[:frontend_host],
     allow_headers: ~w(Authorization Content-Type Accept Origin),
     expose_headers: ~w(Authorization Content-Type)
 


### PR DESCRIPTION
I just realized recently that we're actually supporting localhost in production when it comes to cors. That is a huge security risk and we don't want to do that.